### PR TITLE
Check for toolbar config being passed in through props, remove default array

### DIFF
--- a/src/Quill.vue
+++ b/src/Quill.vue
@@ -78,6 +78,10 @@
                 }
             }
 
+            if (this.config.modules && this.config.modules.toolbar) {
+                this.defaultConfig.modules.toolbar = []
+            }
+
             Quill.register(GrammarlyInline)
 
             this.editor = new Quill(this.$refs.quill, defaultsDeep(this.config, this.defaultConfig))


### PR DESCRIPTION
This will check to see if a toolbar config is sent through the props and remove the defaults that are being merged in to the ultimate config.

@pdesmarais would you mind testing? 
Resolves #16 

