### PR TITLE
Stop initial focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-quill",
-  "version": "1.4.0",
+  "version": "1.5.0-0",
   "description": "Vue quill component and filter",
   "main": "vue-quill.js",
   "browserify": {

--- a/src/Quill.vue
+++ b/src/Quill.vue
@@ -88,7 +88,7 @@
 
             if (this.content && this.content !== '') {
 	            if (this.output != 'delta') {
-	                this.editor.pasteHTML(this.content)
+                    this.editor.root.innerHTML = this.content
 	            } else {
 	                this.editor.setContents(this.content)
 	            }


### PR DESCRIPTION
When using `output="html"` the focus was automatically being set on mount. This is a side effect of the deprecated [pasteHtml](https://quilljs.com/docs/api/#pastehtml) method.

I have changed this to set the raw innerHTML of the editor which does not have the focus stealing side effects.

This behaviour can be previewed in this [sandbox](https://codesandbox.io/s/qqr13100y4)

Resolves #22 